### PR TITLE
feat: impl templete insert

### DIFF
--- a/frontend/app/docs/[...slug]/NewPageEditor.tsx
+++ b/frontend/app/docs/[...slug]/NewPageEditor.tsx
@@ -2,8 +2,8 @@ import { fetchAllPages } from '@/lib/wiki';
 
 import NewPageEditorClient from './NewPageEditorClient';
 
-export default async function NewPageEditor() {
+export default async function NewPageEditor({ initialTitle }: { initialTitle?: string }) {
   const allPages = await fetchAllPages();
 
-  return <NewPageEditorClient allPages={allPages} />;
+  return <NewPageEditorClient allPages={allPages} initialTitle={initialTitle} />;
 }

--- a/frontend/app/docs/[...slug]/NewPageEditorClient.tsx
+++ b/frontend/app/docs/[...slug]/NewPageEditorClient.tsx
@@ -1,20 +1,23 @@
 'use client';
 
-import { useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 
-import MarkdownEditor from '@/components/WikiEditor';
 import { createWikiPage } from '@/lib/wiki';
 import { decodeSlug, parseMarkdown, slugify } from '@/lib/parseMarkdown';
 import WikiEditorWrapper from '@/components/WikiEditorWrapper';
 
 export default function NewPageEditorClient({
   allPages,
+  initialTitle,
 }: {
   allPages: { id: number; title: string; path: string }[];
+  initialTitle?: string;
 }) {
-  const markdown = '# 새 문서 만들기\n본문을 작성해주세요!';
+  const markdown = initialTitle
+    ? `# ${initialTitle}\n본문을 작성해주세요!`
+    : '# 새 문서 만들기\n본문을 작성해주세요!';
   const params = useParams();
+
   const slugList = decodeSlug(params.slug?.slice(0, -1));
   const parentPath = slugList.join('/');
 
@@ -23,7 +26,9 @@ export default function NewPageEditorClient({
       const { title, body } = parseMarkdown(markdownForStorage);
       const slug = slugify(title);
 
-      const res = await createWikiPage(title, `${parentPath}/${slug}`, body);
+      const newPath = parentPath ? `${parentPath}/${slug}` : slug;
+
+      const res = await createWikiPage(title, newPath, body);
 
       if (res?.data?.pages?.create?.responseResult?.succeeded) {
         window.location.reload();

--- a/frontend/app/docs/[...slug]/page.tsx
+++ b/frontend/app/docs/[...slug]/page.tsx
@@ -1,11 +1,20 @@
 import { fetchAllPages, getWikiPage } from '@/lib/wiki';
 import { titleFromSlug } from '@/lib/parseMarkdown';
+import { injectTemplates } from '@/lib/templateRenderer';
 
 import ClientEditor from './ClientEditor';
 import NewPageEditor from './NewPageEditor';
 
-export default async function DocsPage({ params }: { params: Promise<{ slug?: string[] }> }) {
+export default async function DocsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ slug?: string[] }>;
+  searchParams: Promise<{ mode?: string }>;
+}) {
   const { slug } = await params;
+  const { mode } = await searchParams;
+
   const safeSlug = slug ?? ['home'];
   const title = titleFromSlug(safeSlug[safeSlug.length - 1]);
   const rawPath = safeSlug.join('/');
@@ -20,9 +29,29 @@ export default async function DocsPage({ params }: { params: Promise<{ slug?: st
   if (temp === '_new') {
     return <NewPageEditor />;
   }
-  if (!page) return <div>Not Found</div>;
+  if (!page) {
+    if (mode === 'edit') {
+      return <NewPageEditor initialTitle={title} />;
+    }
+
+    return (
+      <div className="max-w-3xl mx-auto p-6">
+        <h1 className="text-2xl font-bold mb-4">{title}</h1>
+        <p className="text-gray-600 mb-2">페이지가 존재하지 않습니다.</p>
+        <a
+          href={`/docs/${rawPath}?mode=edit`}
+          className="inline-block px-4 py-2 bg-gray-600 text-white hover:bg-gray-700 transition-colors"
+        >
+          페이지 생성
+        </a>
+      </div>
+    );
+  }
+
+  const rendered = await injectTemplates(page.render);
+  const pageWithTemplates = { ...page, render: rendered };
 
   const allPages = await fetchAllPages();
 
-  return <ClientEditor page={page} title={title} allPages={allPages} />;
+  return <ClientEditor page={pageWithTemplates} title={title} allPages={allPages} />;
 }

--- a/frontend/lib/parseMarkdown.ts
+++ b/frontend/lib/parseMarkdown.ts
@@ -16,7 +16,7 @@ export function slugify(title: string) {
   return title
     .trim()
     .toLowerCase()
-    .replace(/[^\p{L}\p{N}\s-]/gu, '')
+    .replace(/[^\p{L}\p{N}\s\-:]/gu, '')
     .replace(/\s+/g, '-');
 }
 

--- a/frontend/lib/templateRenderer.ts
+++ b/frontend/lib/templateRenderer.ts
@@ -1,0 +1,39 @@
+import { getWikiPage } from '@/lib/wiki';
+
+export async function injectTemplates(html: string): Promise<string> {
+  const templateRegex = /\(\*\s*(틀:[^\)]+)\)/g;
+  const matches = [...html.matchAll(templateRegex)];
+
+  if (matches.length === 0) return html;
+
+  const uniqueTemplateNames = Array.from(new Set(matches.map((m) => m[1].trim())));
+
+  const templatesData = await Promise.all(
+    uniqueTemplateNames.map(async (name) => {
+      const page = await getWikiPage(name).catch(() => null);
+      return { name, render: page?.render || null };
+    })
+  );
+
+  const templateMap = new Map(templatesData.map((t) => [t.name, t.render]));
+  let resultHtml = html;
+
+  for (const match of matches) {
+    const rawTag = match[0];
+    const name = match[1].trim();
+    const content = templateMap.get(name);
+
+    const safePath = encodeURIComponent(name);
+    const basePath = `/docs/${safePath}`;
+
+    if (content) {
+      const templateWrapper = `<div class="wiki-template-container my-6"><div class="wiki-vde text-[11px] text-gray-400 flex gap-1 leading-none border-none mb-0 opacity-70 hover:opacity-100 transition-opacity"><a href="${basePath}" class="hover:text-blue-600 hover:underline" title="보기">V</a>&middot;<a href="${basePath}/discuss" class="hover:text-blue-600 hover:underline" title="토론">D</a>&middot;<a href="${basePath}?mode=edit" class="hover:text-blue-600 hover:underline" title="편집">E</a></div><div class="wiki-template-content w-full border-none [&>*:first-child]:!mt-1 [&>*:last-child]:!mb-0">${content}</div></div>`;
+      resultHtml = resultHtml.replace(rawTag, templateWrapper);
+    } else {
+      const missingLink = `<a href="${basePath}?mode=edit" style="color:#ba0000;font-weight:500;border:1px dashed #ba0000;padding:2px 4px;font-size:0.9em;">[${name} (생성 필요)]</a>`;
+      resultHtml = resultHtml.replace(rawTag, missingLink);
+    }
+  }
+
+  return resultHtml;
+}


### PR DESCRIPTION
<img width="949" height="746" alt="image" src="https://github.com/user-attachments/assets/5f09ae79-b6b9-49dc-a35a-848edaf5eb1f" />

별도의 DB를 만드는 방식이 아닌 "틀:" 로 시작하는 위키 문서를 만들어 집어넣는 방식으로 구현

작성되지 않은 문서에 접근 후 수정 시 이름이 자동으로 입력되게 구현