### PR TITLE
feat: impl templete with argument

### DIFF
--- a/frontend/app/docs/[...slug]/ClientEditor.tsx
+++ b/frontend/app/docs/[...slug]/ClientEditor.tsx
@@ -42,8 +42,7 @@ function ClientEditor({
       try {
         await softDeleteWikiPage(page.id, oldPath);
 
-        router.refresh();
-        router.replace('/');
+        window.location.href = '/';
       } catch (error) {
         console.error('문서 삭제 중 오류가 발생했습니다:', error);
         alert('문서를 삭제하는 데 실패했습니다. 다시 시도해 주세요.');
@@ -69,8 +68,7 @@ function ClientEditor({
 
             await updatePageAndChildren(page.id, oldPath, newPath, newTitle, body);
 
-            router.push(`/docs/${newPath}`);
-            router.refresh();
+            window.location.href = `/docs/${newPath}`;
           }}
         />
         <div className="mt-4 text-center">

--- a/frontend/lib/templateRenderer.ts
+++ b/frontend/lib/templateRenderer.ts
@@ -64,6 +64,7 @@ export async function injectTemplates(html: string): Promise<string> {
         }
       );
 
+      // TODO: 디자인 추가하기
       const templateWrapper = `<div class="wiki-template-container my-6"><div class="wiki-vde text-[11px] text-gray-400 flex gap-1 leading-none border-none mb-0 opacity-70 hover:opacity-100 transition-opacity"><a href="${basePath}" class="hover:text-blue-600 hover:underline" title="보기">V</a>&middot;<a href="${basePath}/discuss" class="hover:text-blue-600 hover:underline" title="토론">D</a>&middot;<a href="${basePath}?mode=edit" class="hover:text-blue-600 hover:underline" title="편집">E</a></div><div class="wiki-template-content w-full border-none [&>*:first-child]:!mt-1 [&>*:last-child]:!mb-0">${processedContent}</div></div>`;
 
       resultHtml = resultHtml.replace(rawTag, templateWrapper);

--- a/frontend/lib/templateRenderer.ts
+++ b/frontend/lib/templateRenderer.ts
@@ -3,6 +3,7 @@ import { getWikiPage } from '@/lib/wiki';
 export async function injectTemplates(html: string): Promise<string> {
   if (!html || typeof html !== 'string') return html || '';
 
+  // (* 틀:TemplateName | arg1=val1 | arg2=val2) 템플릿 호출 찾기
   const templateRegex = /\(\*\s*(틀:[^|)]+)(?:\|([^)]+))?\)/g;
   const matches = [...html.matchAll(templateRegex)];
 
@@ -17,6 +18,7 @@ export async function injectTemplates(html: string): Promise<string> {
     })
   );
 
+  // 템플릿 이름과 렌더링된 HTML을 매핑
   const templateMap = new Map(templatesData.map((t) => [t.name, t.render]));
   let resultHtml = html;
 
@@ -30,6 +32,7 @@ export async function injectTemplates(html: string): Promise<string> {
     const basePath = `/docs/${safePath}`;
 
     if (rawContent) {
+      // 인자 파싱
       const args: Record<string, string> = {};
 
       if (argString) {
@@ -51,10 +54,12 @@ export async function injectTemplates(html: string): Promise<string> {
         });
       }
 
+      // 템플릿의 {{{변수명}}} 치환 처리
       const processedContent = rawContent.replace(
         /\{\{\{([^}]+)\}\}\}/g,
         (_: string, key: string) => {
           const trimmedKey = key.trim();
+          // 인자가 제공되지 않은 경우 빈 문자열 반환
           return args[trimmedKey] !== undefined ? args[trimmedKey] : '';
         }
       );

--- a/frontend/lib/templateRenderer.ts
+++ b/frontend/lib/templateRenderer.ts
@@ -1,7 +1,9 @@
 import { getWikiPage } from '@/lib/wiki';
 
 export async function injectTemplates(html: string): Promise<string> {
-  const templateRegex = /\(\*\s*(틀:[^\)]+)\)/g;
+  if (!html || typeof html !== 'string') return html || '';
+
+  const templateRegex = /\(\*\s*(틀:[^|)]+)(?:\|([^)]+))?\)/g;
   const matches = [...html.matchAll(templateRegex)];
 
   if (matches.length === 0) return html;
@@ -19,15 +21,46 @@ export async function injectTemplates(html: string): Promise<string> {
   let resultHtml = html;
 
   for (const match of matches) {
-    const rawTag = match[0];
-    const name = match[1].trim();
-    const content = templateMap.get(name);
+    const rawTag = match[0]; // (* 틀:회장 | 이름=최정흠 | 소속=항공우주공학과)
+    const name = match[1].trim(); // 틀:회장
+    const argString = match[2]; // 이름=최정흠 | 소속=항공우주공학과
 
+    const rawContent = templateMap.get(name);
     const safePath = encodeURIComponent(name);
     const basePath = `/docs/${safePath}`;
 
-    if (content) {
-      const templateWrapper = `<div class="wiki-template-container my-6"><div class="wiki-vde text-[11px] text-gray-400 flex gap-1 leading-none border-none mb-0 opacity-70 hover:opacity-100 transition-opacity"><a href="${basePath}" class="hover:text-blue-600 hover:underline" title="보기">V</a>&middot;<a href="${basePath}/discuss" class="hover:text-blue-600 hover:underline" title="토론">D</a>&middot;<a href="${basePath}?mode=edit" class="hover:text-blue-600 hover:underline" title="편집">E</a></div><div class="wiki-template-content w-full border-none [&>*:first-child]:!mt-1 [&>*:last-child]:!mb-0">${content}</div></div>`;
+    if (rawContent) {
+      const args: Record<string, string> = {};
+
+      if (argString) {
+        const parts = argString.split('|');
+
+        parts.forEach((part) => {
+          const trimmed = part.trim();
+          const eqIndex = trimmed.indexOf('=');
+
+          if (eqIndex !== -1) {
+            const key = trimmed.substring(0, eqIndex).trim();
+            const val = trimmed.substring(eqIndex + 1).trim();
+            args[key] = val;
+          } else if (trimmed.length > 0) {
+            console.warn(
+              `[Template] 무시된 인자: "${trimmed}". 틀(${name}) 호출 시 모든 인자는 '이름=값' 형태여야 합니다.`
+            );
+          }
+        });
+      }
+
+      const processedContent = rawContent.replace(
+        /\{\{\{([^}]+)\}\}\}/g,
+        (_: string, key: string) => {
+          const trimmedKey = key.trim();
+          return args[trimmedKey] !== undefined ? args[trimmedKey] : '';
+        }
+      );
+
+      const templateWrapper = `<div class="wiki-template-container my-6"><div class="wiki-vde text-[11px] text-gray-400 flex gap-1 leading-none border-none mb-0 opacity-70 hover:opacity-100 transition-opacity"><a href="${basePath}" class="hover:text-blue-600 hover:underline" title="보기">V</a>&middot;<a href="${basePath}/discuss" class="hover:text-blue-600 hover:underline" title="토론">D</a>&middot;<a href="${basePath}?mode=edit" class="hover:text-blue-600 hover:underline" title="편집">E</a></div><div class="wiki-template-content w-full border-none [&>*:first-child]:!mt-1 [&>*:last-child]:!mb-0">${processedContent}</div></div>`;
+
       resultHtml = resultHtml.replace(rawTag, templateWrapper);
     } else {
       const missingLink = `<a href="${basePath}?mode=edit" style="color:#ba0000;font-weight:500;border:1px dashed #ba0000;padding:2px 4px;font-size:0.9em;">[${name} (생성 필요)]</a>`;


### PR DESCRIPTION
It closes #54 

틀의 {{{인자1}}} {{{인자2}}} 를
(*틀 이름 | 인자1=값 | 인자2=값) 의 형태로 치환 가능
<img width="698" height="395" alt="image" src="https://github.com/user-attachments/assets/bf1ae9f0-1db9-4708-9809-3e5e61ea93c7" />
<img width="355" height="141" alt="image" src="https://github.com/user-attachments/assets/317cccc5-8f83-4631-a99f-cd22cf2844cc" />
<img width="707" height="544" alt="image" src="https://github.com/user-attachments/assets/e03e32ad-b4a3-4d9c-b18f-9c2dc052202d" />
